### PR TITLE
add license select before file upload to wikimedia

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -113,10 +113,6 @@ body {
   background-color: white !important ;
 }
 
-#wpLicense {
-  margin-bottom: 2rem;
-}
-
 /* Custom page CSS
 -------------------------------------------------- */
 /* Not required for template or sticky footer method. */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -113,6 +113,10 @@ body {
   background-color: white !important ;
 }
 
+#wpLicense {
+  margin-bottom: 2rem;
+}
+
 /* Custom page CSS
 -------------------------------------------------- */
 /* Not required for template or sticky footer method. */

--- a/uploader/templates/license.html
+++ b/uploader/templates/license.html
@@ -1,0 +1,152 @@
+<h6>License</h6>
+<select name="wpLicense" id="wpLicense" class="custom-select">
+  <option title="none" value="">None selected</option>
+  <option title="subst:uwl" value="subst:uwl"
+    >I don't know what the license is</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >Your own work (best practices):</option
+  >
+  <option
+    title="self|GFDL|cc-by-sa-all|migration=redundant"
+    value="self|GFDL|cc-by-sa-all|migration=redundant"
+    >&nbsp;&nbsp;Own work, copyleft, attribution required (Multi-license GFDL,
+    CC BY-SA all versions)
+  </option>
+  <option title="self|Cc-zero" value="self|Cc-zero"
+    >&nbsp;&nbsp;CC0 1.0 Universal Public Domain Dedication, all rights waived
+    (Public domain)</option
+  >
+  <option title="PD-self" value="PD-self"
+    >&nbsp;&nbsp;Own work, all rights released (Public domain)</option
+  >
+  <option
+    title="self|GFDL|cc-by-sa-4.0|migration=redundant"
+    value="self|GFDL|cc-by-sa-4.0|migration=redundant"
+    >&nbsp;&nbsp;Own work, copyleft, attribution required (GFDL, CC BY-SA
+    4.0)</option
+  >
+  <option
+    title="self|GFDL|cc-by-4.0|migration=redundant"
+    value="self|GFDL|cc-by-4.0|migration=redundant"
+    >&nbsp;&nbsp;Own work, attribution required (GFDL, CC BY 4.0)</option
+  >
+  <option title="self|cc-by-sa-4.0" value="self|cc-by-sa-4.0"
+    >&nbsp;&nbsp;Own work, copyleft, attribution required (CC BY-SA 4.0)</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >Not self-made, but has been released under:</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >&nbsp;&nbsp;Creative Commons licenses</option
+  >
+  <option title="cc-by-sa-4.0" value="cc-by-sa-4.0"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 4.0</option
+  >
+  <option title="cc-by-sa-3.0" value="cc-by-sa-3.0"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 3.0</option
+  >
+  <option title="cc-by-4.0" value="cc-by-4.0"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 4.0</option
+  >
+  <option title="cc-by-3.0" value="cc-by-3.0"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 3.0</option
+  >
+  <option title="Cc-zero" value="Cc-zero"
+    >&nbsp;&nbsp;&nbsp;&nbsp;CC0 1.0 universell Public domain-dedikation
+  </option>
+  <option disabled="disabled" style="color: GrayText" value=""
+    >&nbsp;&nbsp;Free Art License</option
+  >
+  <option title="FAL" value="FAL"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Free Art License</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >&nbsp;&nbsp;Flickr photos</option
+  >
+  <option
+    title="subst:template 2|flickrreview|subst:uwl"
+    value="subst:template 2|flickrreview|subst:uwl"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Image from Flickr and I do not know the
+    license</option
+  >
+  <option
+    title="subst:template 2|cc-by-sa-2.0|flickrreview"
+    value="subst:template 2|cc-by-sa-2.0|flickrreview"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
+    Attribution ShareAlike 2.0</option
+  >
+  <option
+    title="subst:template 2|cc-by-2.0|flickrreview"
+    value="subst:template 2|cc-by-2.0|flickrreview"
+    >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
+    Attribution 2.0</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >Public domain:</option
+  >
+  <option title="PD-old-100" value="PD-old-100"
+    >&nbsp;&nbsp;Author died more than 100 years ago</option
+  >
+  <option title="PD-old-100-1923" value="PD-old-100-1923"
+    >&nbsp;&nbsp;Author died more than 100 years ago AND the work was published
+    before 1923</option
+  >
+  <option title="PD-old-70-1923" value="PD-old-70-1923"
+    >&nbsp;&nbsp;Author died more than 70 years ago AND the work was published
+    before 1923</option
+  >
+  <option
+    title="PD-old-70|Unclear-PD-US-old-70"
+    value="PD-old-70|Unclear-PD-US-old-70"
+    >&nbsp;&nbsp;Author died more than 70 years ago BUT the work was published
+    after 1923</option
+  >
+  <option title="PD-Art" value="PD-Art"
+    >&nbsp;&nbsp;Reproduction of a painting or other 2D work that is in the
+    public domain because of its age â€“ needs specification after
+    uploading</option
+  >
+  <option title="PD-US" value="PD-US"
+    >&nbsp;&nbsp;First published in the United States before 1923</option
+  >
+  <option title="PD-US-no notice" value="PD-US-no notice"
+    >&nbsp;&nbsp;First published in the United States between 1923 and 1977
+    without a copyright notice</option
+  >
+  <option title="PD-USGov" value="PD-USGov"
+    >&nbsp;&nbsp;Original work of the US Federal Government</option
+  >
+  <option title="PD-USGov-NASA" value="PD-USGov-NASA"
+    >&nbsp;&nbsp;Original work of NASA</option
+  >
+  <option title="PD-USGov-Military-Navy" value="PD-USGov-Military-Navy"
+    >&nbsp;&nbsp;Original work of the US Military Navy</option
+  >
+  <option title="PD-ineligible" value="PD-ineligible"
+    >&nbsp;&nbsp;Too simple to be copyrighted</option
+  >
+  <option
+    title="subst:Template 2|PD-textlogo|Trademarked"
+    value="subst:Template 2|PD-textlogo|Trademarked"
+    >&nbsp;&nbsp;Logo with only simple text (wordmark)</option
+  >
+  <option disabled="disabled" style="color: GrayText" value=""
+    >Other alternatives:</option
+  >
+  <option title="subst:uwl" value="subst:uwl"
+    >&nbsp;&nbsp;I found the image on Google or a random website</option
+  >
+  <option title="Fair use" value="Fair use"
+    >&nbsp;&nbsp;Fair use image (Not allowed on Commons. Image will be
+    deleted.)</option
+  >
+  <option title="Copyrighted free use" value="Copyrighted free use"
+    >&nbsp;&nbsp;Copyrighted, but may be used for any purpose, including
+    commercially</option
+  >
+  <option title="Attribution" value="Attribution"
+    >&nbsp;&nbsp;May be used for any purpose, including commercially, if the
+    copyright holder is properly attributed</option
+  >
+</select>

--- a/uploader/templates/license.html
+++ b/uploader/templates/license.html
@@ -1,152 +1,154 @@
-<h6>License</h6>
-<select name="wpLicense" id="wpLicense" class="custom-select">
-  <option title="none" value="">None selected</option>
-  <option title="subst:uwl" value="subst:uwl"
-    >I don't know what the license is</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >Your own work (best practices):</option
-  >
-  <option
-    title="self|GFDL|cc-by-sa-all|migration=redundant"
-    value="self|GFDL|cc-by-sa-all|migration=redundant"
-    >&nbsp;&nbsp;Own work, copyleft, attribution required (Multi-license GFDL,
-    CC BY-SA all versions)
-  </option>
-  <option title="self|Cc-zero" value="self|Cc-zero"
-    >&nbsp;&nbsp;CC0 1.0 Universal Public Domain Dedication, all rights waived
-    (Public domain)</option
-  >
-  <option title="PD-self" value="PD-self"
-    >&nbsp;&nbsp;Own work, all rights released (Public domain)</option
-  >
-  <option
-    title="self|GFDL|cc-by-sa-4.0|migration=redundant"
-    value="self|GFDL|cc-by-sa-4.0|migration=redundant"
-    >&nbsp;&nbsp;Own work, copyleft, attribution required (GFDL, CC BY-SA
-    4.0)</option
-  >
-  <option
-    title="self|GFDL|cc-by-4.0|migration=redundant"
-    value="self|GFDL|cc-by-4.0|migration=redundant"
-    >&nbsp;&nbsp;Own work, attribution required (GFDL, CC BY 4.0)</option
-  >
-  <option title="self|cc-by-sa-4.0" value="self|cc-by-sa-4.0"
-    >&nbsp;&nbsp;Own work, copyleft, attribution required (CC BY-SA 4.0)</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >Not self-made, but has been released under:</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >&nbsp;&nbsp;Creative Commons licenses</option
-  >
-  <option title="cc-by-sa-4.0" value="cc-by-sa-4.0"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 4.0</option
-  >
-  <option title="cc-by-sa-3.0" value="cc-by-sa-3.0"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 3.0</option
-  >
-  <option title="cc-by-4.0" value="cc-by-4.0"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 4.0</option
-  >
-  <option title="cc-by-3.0" value="cc-by-3.0"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 3.0</option
-  >
-  <option title="Cc-zero" value="Cc-zero"
-    >&nbsp;&nbsp;&nbsp;&nbsp;CC0 1.0 universell Public domain-dedikation
-  </option>
-  <option disabled="disabled" style="color: GrayText" value=""
-    >&nbsp;&nbsp;Free Art License</option
-  >
-  <option title="FAL" value="FAL"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Free Art License</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >&nbsp;&nbsp;Flickr photos</option
-  >
-  <option
-    title="subst:template 2|flickrreview|subst:uwl"
-    value="subst:template 2|flickrreview|subst:uwl"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Image from Flickr and I do not know the
-    license</option
-  >
-  <option
-    title="subst:template 2|cc-by-sa-2.0|flickrreview"
-    value="subst:template 2|cc-by-sa-2.0|flickrreview"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
-    Attribution ShareAlike 2.0</option
-  >
-  <option
-    title="subst:template 2|cc-by-2.0|flickrreview"
-    value="subst:template 2|cc-by-2.0|flickrreview"
-    >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
-    Attribution 2.0</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >Public domain:</option
-  >
-  <option title="PD-old-100" value="PD-old-100"
-    >&nbsp;&nbsp;Author died more than 100 years ago</option
-  >
-  <option title="PD-old-100-1923" value="PD-old-100-1923"
-    >&nbsp;&nbsp;Author died more than 100 years ago AND the work was published
-    before 1923</option
-  >
-  <option title="PD-old-70-1923" value="PD-old-70-1923"
-    >&nbsp;&nbsp;Author died more than 70 years ago AND the work was published
-    before 1923</option
-  >
-  <option
-    title="PD-old-70|Unclear-PD-US-old-70"
-    value="PD-old-70|Unclear-PD-US-old-70"
-    >&nbsp;&nbsp;Author died more than 70 years ago BUT the work was published
-    after 1923</option
-  >
-  <option title="PD-Art" value="PD-Art"
-    >&nbsp;&nbsp;Reproduction of a painting or other 2D work that is in the
-    public domain because of its age â€“ needs specification after
-    uploading</option
-  >
-  <option title="PD-US" value="PD-US"
-    >&nbsp;&nbsp;First published in the United States before 1923</option
-  >
-  <option title="PD-US-no notice" value="PD-US-no notice"
-    >&nbsp;&nbsp;First published in the United States between 1923 and 1977
-    without a copyright notice</option
-  >
-  <option title="PD-USGov" value="PD-USGov"
-    >&nbsp;&nbsp;Original work of the US Federal Government</option
-  >
-  <option title="PD-USGov-NASA" value="PD-USGov-NASA"
-    >&nbsp;&nbsp;Original work of NASA</option
-  >
-  <option title="PD-USGov-Military-Navy" value="PD-USGov-Military-Navy"
-    >&nbsp;&nbsp;Original work of the US Military Navy</option
-  >
-  <option title="PD-ineligible" value="PD-ineligible"
-    >&nbsp;&nbsp;Too simple to be copyrighted</option
-  >
-  <option
-    title="subst:Template 2|PD-textlogo|Trademarked"
-    value="subst:Template 2|PD-textlogo|Trademarked"
-    >&nbsp;&nbsp;Logo with only simple text (wordmark)</option
-  >
-  <option disabled="disabled" style="color: GrayText" value=""
-    >Other alternatives:</option
-  >
-  <option title="subst:uwl" value="subst:uwl"
-    >&nbsp;&nbsp;I found the image on Google or a random website</option
-  >
-  <option title="Fair use" value="Fair use"
-    >&nbsp;&nbsp;Fair use image (Not allowed on Commons. Image will be
-    deleted.)</option
-  >
-  <option title="Copyrighted free use" value="Copyrighted free use"
-    >&nbsp;&nbsp;Copyrighted, but may be used for any purpose, including
-    commercially</option
-  >
-  <option title="Attribution" value="Attribution"
-    >&nbsp;&nbsp;May be used for any purpose, including commercially, if the
-    copyright holder is properly attributed</option
-  >
-</select>
+<label class="d-flex align-items-center mb-3">
+    <span>Licensing:</span>
+    <select name="wpLicense" id="wpLicense" class="custom-select ml-1">
+      <option title="none" value="">None selected</option>
+      <option title="subst:uwl" value="subst:uwl"
+        >I don't know what the license is</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >Your own work (best practices):</option
+      >
+      <option
+        title="self|GFDL|cc-by-sa-all|migration=redundant"
+        value="self|GFDL|cc-by-sa-all|migration=redundant"
+        >&nbsp;&nbsp;Own work, copyleft, attribution required (Multi-license GFDL,
+        CC BY-SA all versions)
+      </option>
+      <option title="self|Cc-zero" value="self|Cc-zero"
+        >&nbsp;&nbsp;CC0 1.0 Universal Public Domain Dedication, all rights waived
+        (Public domain)</option
+      >
+      <option title="PD-self" value="PD-self"
+        >&nbsp;&nbsp;Own work, all rights released (Public domain)</option
+      >
+      <option
+        title="self|GFDL|cc-by-sa-4.0|migration=redundant"
+        value="self|GFDL|cc-by-sa-4.0|migration=redundant"
+        >&nbsp;&nbsp;Own work, copyleft, attribution required (GFDL, CC BY-SA
+        4.0)</option
+      >
+      <option
+        title="self|GFDL|cc-by-4.0|migration=redundant"
+        value="self|GFDL|cc-by-4.0|migration=redundant"
+        >&nbsp;&nbsp;Own work, attribution required (GFDL, CC BY 4.0)</option
+      >
+      <option title="self|cc-by-sa-4.0" value="self|cc-by-sa-4.0"
+        >&nbsp;&nbsp;Own work, copyleft, attribution required (CC BY-SA 4.0)</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >Not self-made, but has been released under:</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >&nbsp;&nbsp;Creative Commons licenses</option
+      >
+      <option title="cc-by-sa-4.0" value="cc-by-sa-4.0"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 4.0</option
+      >
+      <option title="cc-by-sa-3.0" value="cc-by-sa-3.0"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Attribution ShareAlike 3.0</option
+      >
+      <option title="cc-by-4.0" value="cc-by-4.0"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 4.0</option
+      >
+      <option title="cc-by-3.0" value="cc-by-3.0"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Attribution 3.0</option
+      >
+      <option title="Cc-zero" value="Cc-zero"
+        >&nbsp;&nbsp;&nbsp;&nbsp;CC0 1.0 universell Public domain-dedikation
+      </option>
+      <option disabled="disabled" style="color: GrayText" value=""
+        >&nbsp;&nbsp;Free Art License</option
+      >
+      <option title="FAL" value="FAL"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Free Art License</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >&nbsp;&nbsp;Flickr photos</option
+      >
+      <option
+        title="subst:template 2|flickrreview|subst:uwl"
+        value="subst:template 2|flickrreview|subst:uwl"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Image from Flickr and I do not know the
+        license</option
+      >
+      <option
+        title="subst:template 2|cc-by-sa-2.0|flickrreview"
+        value="subst:template 2|cc-by-sa-2.0|flickrreview"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
+        Attribution ShareAlike 2.0</option
+      >
+      <option
+        title="subst:template 2|cc-by-2.0|flickrreview"
+        value="subst:template 2|cc-by-2.0|flickrreview"
+        >&nbsp;&nbsp;&nbsp;&nbsp;Uploaded to Flickr under Creative Commons
+        Attribution 2.0</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >Public domain:</option
+      >
+      <option title="PD-old-100" value="PD-old-100"
+        >&nbsp;&nbsp;Author died more than 100 years ago</option
+      >
+      <option title="PD-old-100-1923" value="PD-old-100-1923"
+        >&nbsp;&nbsp;Author died more than 100 years ago AND the work was published
+        before 1923</option
+      >
+      <option title="PD-old-70-1923" value="PD-old-70-1923"
+        >&nbsp;&nbsp;Author died more than 70 years ago AND the work was published
+        before 1923</option
+      >
+      <option
+        title="PD-old-70|Unclear-PD-US-old-70"
+        value="PD-old-70|Unclear-PD-US-old-70"
+        >&nbsp;&nbsp;Author died more than 70 years ago BUT the work was published
+        after 1923</option
+      >
+      <option title="PD-Art" value="PD-Art"
+        >&nbsp;&nbsp;Reproduction of a painting or other 2D work that is in the
+        public domain because of its age â€“ needs specification after
+        uploading</option
+      >
+      <option title="PD-US" value="PD-US"
+        >&nbsp;&nbsp;First published in the United States before 1923</option
+      >
+      <option title="PD-US-no notice" value="PD-US-no notice"
+        >&nbsp;&nbsp;First published in the United States between 1923 and 1977
+        without a copyright notice</option
+      >
+      <option title="PD-USGov" value="PD-USGov"
+        >&nbsp;&nbsp;Original work of the US Federal Government</option
+      >
+      <option title="PD-USGov-NASA" value="PD-USGov-NASA"
+        >&nbsp;&nbsp;Original work of NASA</option
+      >
+      <option title="PD-USGov-Military-Navy" value="PD-USGov-Military-Navy"
+        >&nbsp;&nbsp;Original work of the US Military Navy</option
+      >
+      <option title="PD-ineligible" value="PD-ineligible"
+        >&nbsp;&nbsp;Too simple to be copyrighted</option
+      >
+      <option
+        title="subst:Template 2|PD-textlogo|Trademarked"
+        value="subst:Template 2|PD-textlogo|Trademarked"
+        >&nbsp;&nbsp;Logo with only simple text (wordmark)</option
+      >
+      <option disabled="disabled" style="color: GrayText" value=""
+        >Other alternatives:</option
+      >
+      <option title="subst:uwl" value="subst:uwl"
+        >&nbsp;&nbsp;I found the image on Google or a random website</option
+      >
+      <option title="Fair use" value="Fair use"
+        >&nbsp;&nbsp;Fair use image (Not allowed on Commons. Image will be
+        deleted.)</option
+      >
+      <option title="Copyrighted free use" value="Copyrighted free use"
+        >&nbsp;&nbsp;Copyrighted, but may be used for any purpose, including
+        commercially</option
+      >
+      <option title="Attribution" value="Attribution"
+        >&nbsp;&nbsp;May be used for any purpose, including commercially, if the
+        copyright holder is properly attributed</option
+      >
+    </select>
+</label>

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -38,6 +38,7 @@
                         </div>
 
                         <form class="form-signin">
+                            {% include 'license.html' %}
                             <button
                                     class="btn btn-lg btn-primary btn-block text-uppercase"
                                     type="button"
@@ -350,7 +351,8 @@
     $("#upload-button").toggleClass("disabled");
     var fileData = {
       fileList: fileStagingTable.getData(),
-      token: oauthToken
+      token: oauthToken,
+      license: $("#wpLicense").val()
     };
 
     function getCookie(name) {


### PR DESCRIPTION
**Description**
-  Add a select dropdown containing with licenses options copied from [https://test.wikipedia.org/wiki/Special:Upload](https://test.wikipedia.org/wiki/Special:Upload) by inspecting the browser
- Create a new template file called **license.html** and include in the **upload.html** file
- Style the dropdown in styles.css

**Type of change**
- New feature


![license-added](https://user-images.githubusercontent.com/22874347/76558388-84455200-649d-11ea-8fa2-79ddeb4cdd11.png)
![rsz_license-2](https://user-images.githubusercontent.com/22874347/76558804-3e3cbe00-649e-11ea-9b87-33683bffed66.jpg)
