### PR TITLE
Add license picker for each file

### DIFF
--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -5,6 +5,7 @@ class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
+    license = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 
 class GooglePhotosUploadInputSerializer(serializers.Serializer):

--- a/uploader/templates/licenses.html
+++ b/uploader/templates/licenses.html
@@ -1,8 +1,7 @@
 <div class="d-flex align-items-center mb-3 form-group">
-  <label for="wpLicense" class="control-label">Licensing</label>
   <select
     name="wpLicense"
-    id="wpLicense"
+    id="wpLicense${cell.getData()['id']}"
     class="custom-select ml-1 form-control"
     required="true"
   >

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -11,205 +11,155 @@
 {% endblock %} {% block body %}
 <!-- prettier-ignore -->
 <div class="container">
-        <div class="row">
-            <div class="col-lg-8 mx-auto step-3">
-                <div class="card card-signin my-5">
-                    <div class="card-body">
-                        <div class="row logo-row col-xs-12">
-                            <div class="col-xs-4">
-                                <img
-                                        src="{% static 'svg/Google_Drive_Logo.svg' %}"
-                                        width="100px"
-                                />
-                            </div>
-                            <div class="col-xs-4">
-                                <i class="fas fa-caret-right"></i>
-                            </div>
-                            <div class="col-xs-4">
-                                <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
-                            </div>
-                        </div>
-
-                        <h5 class="app-desc text-center">Your selected file(s):</h5>
-                        <div class="table-responsive">
-                            <table class="table files-table"
-                                   id="picked-files-table">
-                            </table>
-                        </div>
-
-                        <form class="form-signin">
-                            {% include 'licenses.html' %}
-                            <button
-                                    class="btn btn-lg btn-primary btn-block text-uppercase"
-                                    type="button"
-                                    id="upload-button"
-                                    onclick="uploadFiles()"
-                            >
-                                Upload to Wikimedia Commons <i class="fas fa-caret-right"></i>
-                            </button>
-                            <hr class="my-4" />
-                            <h5 class="card-title text-center">
-                                <div class="progress">
-                                    <div
-                                            class="progress-bar"
-                                            role="progressbar"
-                                            style="width: 75%"
-                                            aria-valuenow="75"
-                                            aria-valuemin="0"
-                                            aria-valuemax="100"
-                                    >
-                                        75%
-                                    </div>
-                                </div>
-                            </h5>
-                        </form>
-                    </div>
-                </div>
+  <div class="row">
+    <div class="col-lg-9 mx-auto step-3">
+      <div class="card card-signin my-5">
+        <div class="card-body">
+          <div class="row logo-row col-xs-12">
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Google_Drive_Logo.svg' %}" width="100px" />
             </div>
-
-            <div class="col-sm-9 col-md-7 col-lg-5 mx-auto step-1-2">
-                <div class="card card-signin my-5">
-                    <div class="card-body">
-                        <div class="row logo-row col-xs-12">
-                            <div class="col-xs-4">
-                                <img
-                                        src="{% static 'svg/Google_Drive_Logo.svg' %}"
-                                        width="100px"
-                                />
-                            </div>
-                            <div class="col-xs-4">
-                                <i class="fas fa-caret-right"></i>
-                            </div>
-                            <div class="col-xs-4">
-                                <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
-                            </div>
-                        </div>
-
-                        <h5 class="app-desc text-center">
-                            Upload your photos from Google Drive to Wikimedia Commons!
-                        </h5>
-
-                        <form class="form-signin">
-                            {% if user.is_authenticated %}
-                                <button
-                                        class="btn btn-lg btn-primary btn-block text-uppercase"
-                                        type="button"
-                                        onclick="onGoogleUploadButtonClick()"
-                                >
-                                    Choose photos from Google Drive
-                                    <i class="fas fa-caret-right"></i>
-                                </button>
-                            {% else %}
-                                <a
-                                        href="{% url 'social:begin' 'mediawiki' %}"
-                                        style="text-decoration: none"
-                                >
-                                    <button
-                                            class="btn btn-lg btn-primary btn-block text-uppercase"
-                                            type="button"
-                                    >
-                                        Login to Wikimedia Commons
-                                        <i
-                                                class="fas
-                    fa-caret-right fa-1x"
-                                        ></i>
-                                    </button>
-                                </a>
-                            {% endif %}
-
-                            <hr class="my-4" />
-                            <h5 class="card-title text-center">
-                                <div class="progress">
-                                    {% if user.is_authenticated %}
-                                        <div
-                                                class="progress-bar"
-                                                role="progressbar"
-                                                style="width: 50%"
-                                                aria-valuenow="50"
-                                                aria-valuemin="0"
-                                                aria-valuemax="100"
-                                        >
-                                            50%
-                                        </div>
-                                    {% else %}
-
-                                        <div
-                                                class="progress-bar"
-                                                role="progressbar"
-                                                style="width: 25%"
-                                                aria-valuenow="25"
-                                                aria-valuemin="0"
-                                                aria-valuemax="100"
-                                        >
-                                            25%
-                                        </div>
-                                    {% endif %}
-                                </div>
-                            </h5>
-                        </form>
-                    </div>
-                </div>
+            <div class="col-xs-4">
+              <i class="fas fa-caret-right"></i>
             </div>
-
-            <div class="col-lg-8 mx-auto step-4">
-                <div class="card card-signin my-5">
-                    <div class="card-body">
-                      <div class="row logo-row col-xs-12">
-                        <div class="col-xs-4">
-                            <img
-                                    src="{% static 'svg/Google_Drive_Logo.svg' %}"
-                                    width="100px"
-                            />
-                        </div>
-                        <div class="col-xs-4">
-                            <i class="fas fa-caret-right"></i>
-                        </div>
-                        <div class="col-xs-4">
-                            <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
-                        </div>
-                      </div>
-
-                      <h5 class="app-desc text-center">
-                        The following files were uploaded!
-                      </h5>
-
-                      <div class="table-responsive mb-3">
-                        <table class="table mb-0 results-panel">
-                          <thead>
-                            <tr>
-                              <th style="width: 105px">Preview</th>
-                              <th>Name of file</th>
-                              <th>Link to upload</th>
-                            </tr>
-                          </thead>
-                        </table>
-                      </div>
-
-                      <a class="btn btn-lg btn-primary btn-block text-uppercase" href='{% url "upload_page" %}'>
-                        Upload more <i class="fas fa-caret-right"></i>
-                      </a>
-
-                      <hr class="my-4" />
-
-                      <h5 class="card-title text-center">
-                          <div class="progress">
-                              <div
-                                      class="progress-bar"
-                                      role="progressbar"
-                                      style="width: 100%"
-                                      aria-valuenow="100"
-                                      aria-valuemin="0"
-                                      aria-valuemax="100"
-                              >
-                                  100%
-                              </div>
-                          </div>
-                      </h5>
-                    </div>
-                </div>
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
             </div>
+          </div>
+
+          <h5 class="app-desc text-center">Your selected file(s):</h5>
+          <div class="table-responsive">
+            <table class="table files-table" id="picked-files-table">
+            </table>
+          </div>
+
+          <form class="form-signin">
+            <button class="btn btn-lg btn-primary btn-block text-uppercase" type="button" id="upload-button"
+              onclick="uploadFiles()">
+              Upload to Wikimedia Commons <i class="fas fa-caret-right"></i>
+            </button>
+            <hr class="my-4" />
+            <h5 class="card-title text-center">
+              <div class="progress">
+                <div class="progress-bar" role="progressbar" style="width: 75%" aria-valuenow="75" aria-valuemin="0"
+                  aria-valuemax="100">
+                  75%
+                </div>
+              </div>
+            </h5>
+          </form>
         </div>
+      </div>
     </div>
+
+    <div class="col-sm-9 col-md-7 col-lg-5 mx-auto step-1-2">
+      <div class="card card-signin my-5">
+        <div class="card-body">
+          <div class="row logo-row col-xs-12">
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Google_Drive_Logo.svg' %}" width="100px" />
+            </div>
+            <div class="col-xs-4">
+              <i class="fas fa-caret-right"></i>
+            </div>
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
+            </div>
+          </div>
+
+          <h5 class="app-desc text-center">
+            Upload your photos from Google Drive to Wikimedia Commons!
+          </h5>
+
+          <form class="form-signin">
+            {% if user.is_authenticated %}
+            <button class="btn btn-lg btn-primary btn-block text-uppercase" type="button"
+              onclick="onGoogleUploadButtonClick()">
+              Choose photos from Google Drive
+              <i class="fas fa-caret-right"></i>
+            </button>
+            {% else %}
+            <a href="{% url 'social:begin' 'mediawiki' %}" style="text-decoration: none">
+              <button class="btn btn-lg btn-primary btn-block text-uppercase" type="button">
+                Login to Wikimedia Commons
+                <i class="fas
+                    fa-caret-right fa-1x"></i>
+              </button>
+            </a>
+            {% endif %}
+
+            <hr class="my-4" />
+            <h5 class="card-title text-center">
+              <div class="progress">
+                {% if user.is_authenticated %}
+                <div class="progress-bar" role="progressbar" style="width: 50%" aria-valuenow="50" aria-valuemin="0"
+                  aria-valuemax="100">
+                  50%
+                </div>
+                {% else %}
+
+                <div class="progress-bar" role="progressbar" style="width: 25%" aria-valuenow="25" aria-valuemin="0"
+                  aria-valuemax="100">
+                  25%
+                </div>
+                {% endif %}
+              </div>
+            </h5>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-8 mx-auto step-4">
+      <div class="card card-signin my-5">
+        <div class="card-body">
+          <div class="row logo-row col-xs-12">
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Google_Drive_Logo.svg' %}" width="100px" />
+            </div>
+            <div class="col-xs-4">
+              <i class="fas fa-caret-right"></i>
+            </div>
+            <div class="col-xs-4">
+              <img src="{% static 'svg/Commons-logo.svg' %}" height="100px" />
+            </div>
+          </div>
+
+          <h5 class="app-desc text-center">
+            The following files were uploaded!
+          </h5>
+
+          <div class="table-responsive mb-3">
+            <table class="table mb-0 results-panel">
+              <thead>
+                <tr>
+                  <th style="width: 105px">Preview</th>
+                  <th>Name of file</th>
+                  <th>Link to upload</th>
+                </tr>
+              </thead>
+            </table>
+          </div>
+
+          <a class="btn btn-lg btn-primary btn-block text-uppercase" href='{% url "upload_page" %}'>
+            Upload more <i class="fas fa-caret-right"></i>
+          </a>
+
+          <hr class="my-4" />
+
+          <h5 class="card-title text-center">
+            <div class="progress">
+              <div class="progress-bar" role="progressbar" style="width: 100%" aria-valuenow="100" aria-valuemin="0"
+                aria-valuemax="100">
+                100%
+              </div>
+            </div>
+          </h5>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
 <!-- prettier-ignore -->
 {% endblock body %}
 <!-- prettier-ignore -->
@@ -321,6 +271,14 @@
             width: 80
           },
           {
+            title: "License",
+            field: "license",
+            width: 300,
+            formatter: function(cell, formatterParams, onRendered) {
+              return `{% include 'licenses.html' %}`;
+            }
+          },
+          {
             title: "Title",
             field: "name",
             editor: "input",
@@ -355,9 +313,15 @@
       .addClass("fa-spinner fa-spin");
     var fileData = {
       fileList: fileStagingTable.getData(),
-      token: oauthToken,
-      license: $("#wpLicense").val()
+      token: oauthToken
     };
+
+    for (var x = 0; x < fileData["fileList"].length; x++) {
+      var sel = document.getElementById(
+        `wpLicense${fileData["fileList"][x]["id"]}`
+      );
+      fileData["fileList"][x]["license"] = sel.value;
+    }
 
     function getCookie(name) {
       var cookieValue = null;

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -272,8 +272,9 @@
   // Create and render a Picker object for searching images.
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
-      var view = new google.picker.View(google.picker.ViewId.DOCS);
-      view.setMimeTypes("image/png,image/jpeg,image/jpg");
+      var view = new google.picker.DocsView().setIncludeFolders(true);
+      view.setMimeTypes("image/jpeg,image/jpg,image/gif,image/png,image/bmp");
+      view.setParent('root');
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -81,7 +81,10 @@ class FileUploadViewSet(views.APIView):
                 download_status, done = downloader.next_chunk()
 
             uploaded, image_info = wiki_uploader.upload_file(
-                file_name=file["name"], file_stream=fh, description=file["description"]
+                file_name=file["name"],
+                file_stream=fh,
+                description=file["description"],
+                license=file["license"],
             )
             if uploaded:
                 uploaded_results.append(image_info)

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -47,15 +47,15 @@ class WikiUploader(object):
 
 
 def get_initial_page_text(
-    license="", summary="", category="", date_of_creation="", source="", author=""
+    license=None, summary=None, category=None, date_of_creation=None, source=None, author=None
 ):
-    description = "|description=" + summary + "\n" if summary is not "" else ""
-    date_of_creation = (
-        "|date=" + date_of_creation + "\n" if date_of_creation is not "" else ""
-    )
-    source = "|source=" + source + "\n" if source is not "" else ""
-    author = "|author=" + author + "\n" if author is not "" else ""
-    category = "[[Category:{0}]] ".format(category) + "\n" if category is not "" else ""
+    description = "" if not summary else "|description={0}\n".format(summary)
+    date_of_creation = "" if not date_of_creation else "|date={0}\n".format(
+        date_of_creation)
+    source = "" if not source else "|source={0}\n".format(source)
+    author = "" if not author else "|author={0}\n".format(author)
+    category = "" if not category else "[[Category:{0}]] ".format(
+        category) + "\n"
 
     return """=={{{{int:filedesc}}}}==
 {{{{Information

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -23,23 +23,49 @@ class WikiUploader(object):
             access_secret=access_secret,
         )
 
-    def upload_file(self, file_name, file_stream, description=""):
+    def upload_file(self, file_name, file_stream, description="", license=""):
         if not description:
             description = file_name
 
         upload_result = self.mw_client.upload(
             file=file_stream,
             filename=file_name,
-            description=description,
+            description=get_initial_page_text(license, description),
             ignore=True,
-            comment="Uploaded with Google drive to commons.",
+            comment=description,
         )
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
         )
         logging.debug(debug_information)
         upload_response = upload_result.get("result")
+        print(upload_response)
         if not upload_response == "Success":
             return False, {}
         else:
             return True, upload_result["imageinfo"]
+
+
+def get_initial_page_text(
+    license="", summary="", category="", date_of_creation="", source="", author=""
+):
+    description = "|description=" + summary + "\n" if summary is not "" else ""
+    date_of_creation = (
+        "|date=" + date_of_creation + "\n" if date_of_creation is not "" else ""
+    )
+    source = "|source=" + source + "\n" if source is not "" else ""
+    author = "|author=" + author + "\n" if author is not "" else ""
+    category = "[[Category:{0}]] ".format(category) + "\n" if category is not "" else ""
+
+    return """=={{{{int:filedesc}}}}==
+{{{{Information
+ {0}{1}{2}{3}
+}}}}
+
+
+=={{{{int:license-header}}}}==
+{{{{{4}}}}}
+{5}
+""".format(
+        description, date_of_creation, source, author, license, category,
+    )


### PR DESCRIPTION
Solves two phabricator tasks. `T241596` and  `T241425` .
I have followed the media uploader workflow where we can select the license of each image separately.

Also implemented the serializer for the license and sending the formatted information to the API.

![image](https://user-images.githubusercontent.com/36009198/76702097-0ecfc080-66ed-11ea-8611-f8925ee1975c.png)

![Screenshot_20200315_184755](https://user-images.githubusercontent.com/36009198/76702171-bf3dc480-66ed-11ea-8319-d21400bc271e.png)
