### PR TITLE
Firefox bug

### DIFF
--- a/uploader/templates/base/base.html
+++ b/uploader/templates/base/base.html
@@ -3,12 +3,13 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+
     <meta
       http-equiv="Content-Security-Policy"
       content="default-src 'self' https://* http://*;
           img-src 'self' https://*;
           style-src 'self' 'unsafe-inline';
-          script-src 'self' 'unsafe-inline';
+          script-src 'self' 'unsafe-inline' https://* http://*;
           script-src-elem 'self' https://* http://* 'unsafe-inline';"
     />
 


### PR DESCRIPTION
fixes #40 
The problem was the gapi script was being called but the 'Content-Security-Policy' did not allow any requests to http:// or https://.
Added rules for http and https to the Content-Security-Policy, works on my firefox. 
