### PR TITLE
- Add spinner that displays on the upload button when user clicks to …

### DIFF
--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -347,7 +347,10 @@
 
   function uploadFiles() {
     // Disable the button first.
-    $("#upload-button").toggleClass("disabled");
+    $("#upload-button").prop("disabled", true);
+    $("#upload-button i")
+      .removeClass("fa-caret-right")
+      .addClass("fa-spinner fa-spin");
     var fileData = {
       fileList: fileStagingTable.getData(),
       token: oauthToken
@@ -376,6 +379,13 @@
       return /^(GET|HEAD|OPTIONS|TRACE)$/.test(method);
     }
 
+    function enableUploadButton() {
+      $("#upload-button").prop("disabled", false);
+      $("#upload-button i")
+        .removeClass("fa-spinner fa-spin")
+        .addClass("fa-caret-right");
+    }
+
     $.ajax({
       // prettier-ignore
       url: "{{ request.scheme }}://{{ request.META.HTTP_HOST }}{% url 'file_upload' %}",
@@ -394,6 +404,7 @@
         $(".step-1-2").hide();
         $(".step-4").show();
         $(".results-panel").append("<tbody>");
+        enableUploadButton();
         data.forEach(function(item) {
           $(".results-panel").append(
             `<tr><td><img src='${item.url}' style='width: 50px'></td><td>${item.canonicaltitle}</td><td><a href='${item.url}' target='_blank'>${item.url}</a></td></tr>`
@@ -403,6 +414,7 @@
       },
       error: function() {
         console.log("error");
+        enableUploadButton();
       }
     });
   }


### PR DESCRIPTION
- Add spinner that displays on the upload button when user clicks to upload to wikimedia commons
- Change the way disabling the upload button works (from using ```$("#upload-button").toggleClass('disabled')``` to using ```$("#upload-button").prop('disabled', true)```as the former doesn't prevent the user from clicking multiple time
![gdrive-to-commons-upload-loader](https://user-images.githubusercontent.com/22874347/76856605-e1e9ed80-6853-11ea-9a5c-8cab6d1b07e6.png)
