### PR TITLE
Allow user reselect photos from gdrive after deleting all rows from table

### DIFF
--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -243,7 +243,9 @@
 
   // Use the Google API Loader script to load the google.picker script.
   function onGoogleUploadButtonClick() {
-    gapi.load("auth", { callback: onAuthApiLoad });
+    if (oauthToken === undefined) {
+      gapi.load("auth", { callback: onAuthApiLoad });
+    }
     gapi.load("picker", { callback: onPickerApiLoad });
   }
 
@@ -290,6 +292,15 @@
   function generateGdriveThumbNailLink(itemId) {
     return `https://drive.google.com/thumbnail?authuser=0&sz=w50-h50&id=${itemId}`;
   }
+
+  function checkIfDataExists(data) {
+    if (data.length === 0) {
+      $(".step-3").hide();
+      $(".step-1-2").show();
+      pickedFiles = [];
+    }
+  }
+
   // A simple callback implementation.
   function pickerCallback(data) {
     if (data.action == google.picker.Action.PICKED) {
@@ -306,6 +317,7 @@
 
       fileStagingTable = new Tabulator("#picked-files-table", {
         data: pickedFiles,
+        dataEdited: checkIfDataExists,
         layout: "fitColumns",
         columns: [
           {

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -27,13 +27,18 @@ class WikiUploader(object):
         if not description:
             description = file_name
 
-        upload_result = self.mw_client.upload(
-            file=file_stream,
-            filename=file_name,
-            description=description,
-            ignore=True,
-            comment="Uploaded with Google drive to commons.",
-        )
+        try:
+            upload_result = self.mw_client.upload(
+                file=file_stream,
+                filename=file_name,
+                description=description,
+                ignore=True,
+                comment="Uploaded with Google drive to commons.",
+            )
+        except mwclient.errors.APIError as e:
+            if e.args[0] == "fileexists-no-change":
+                return False, {}
+
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
         )


### PR DESCRIPTION
When the user select photos from gdrive and later deletes all of them, he still remains on thesame step with the button "Upload to wikimedia commons" and when he clicks on it, an empty filelist is uploaded. Below is an image to show what is explained above
![gcommons-1](https://user-images.githubusercontent.com/22874347/76949308-9fceb380-6908-11ea-94b5-fbbca41a743a.PNG)

The following are steps taken to solve the issue above
- Display to user the view to select photos from google drive when user clears the table with picked files
- Edit the call to gapi auth loader to occur only when the oauthToken is not defined to avoid the auth loader called again

