### PR TITLE
Add Categories metadata field for each image 

### DIFF
--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -5,7 +5,7 @@ class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
-
+    categories = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 class GooglePhotosUploadInputSerializer(serializers.Serializer):
     fileList = FileSerializer(many=True)

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -201,14 +201,15 @@
                                       aria-valuemax="100"
                               >
                                   100%
-                              </div>
+                                    </div>
+                               </div>
+                            </h5>
                           </div>
-                      </h5>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+
 <!-- prettier-ignore -->
 {% endblock body %}
 <!-- prettier-ignore -->
@@ -318,6 +319,46 @@
             },
             width: 80
           },
+                    {
+            title: "Categories",
+            field: "categories",
+            formatter: function(cell, formatterParams, onRendered) {
+              return `<select name="wpCategories" id="wpCategories${
+                cell.getData()["id"]
+              }" class="custom-select" value="">
+  
+<option title="Abstract" value="Abstract">Abstract</option>
+<option title="Animals/Wildlife" value="Animals/Wildlife">Animals/Wildlife</option>
+<option title="The Arts" value="The Arts">The Arts</option>
+<option title="Backgroudns/Textures" value="Backgroudns/Textures">Backgroudns/Textures</option>
+<option title="Beauty/Fashion" value="Beauty/Fashion">Beauty/Fashion</option>
+<option title="Buildings/Landmarks" value="Buildings/Landmarks">Buildings/Landmarks</option>
+<option title="Business/Finance" value="Business/Finance">Business/Finance</option>
+<option title="Celebrities" value="Celebrities">Celebrities</option>
+<option title="Editorial" value="Editorial">Editorial</option>
+<option title="Education" value="Education">Education</option>
+<option title="Food and Drink" value="Food and Drink">Food and Drink</option>
+<option title="Healthcare/Medical" value="Healthcare/Medical">Healthcare/Medical</option>
+<option title="Holidays" value="Holidays">Holidays</option>
+<option title="Illustrations/Clip-Art" value="Illustrations/Clip-Art">Illustrations/Clip-Art</option>
+<option title="Industrial" value="Industrial">Industrial</option>
+<option title="Interiors" value="Interiors">Interiors</option>
+<option title="Miscellaneous" value="Miscellaneous">Miscellaneous</option>
+<option title="Nature" value="Nature">Nature</option>
+<option title="Objects" value="Objects">Objects</option>
+<option title="Parks/Outdoor" value="Parks/Outdoor">Parks/Outdoor</option>
+<option title="People" value="People">People</option>
+<option title="Religion" value="Religion">Religion</option>
+<option title="Science" value="Science">Science</option>
+<option title="Signs/Symbols" value="Signs/Symbols">Signs/Symbols</option>
+<option title="Sports/Recreation" value="Sports/Recreation">Sports/Recreation</option>
+<option title="Technology" value="Technology">Technology</option>
+<option title="Transportation" value="Transportation">Transportation</option>
+<option title="Vectors" value="Vectors">Vectors</option>
+<option title="Vintage" value="Vintage">Vintage</option>  
+</select>`;
+            }
+          },                   
           {
             title: "Title",
             field: "name",
@@ -352,6 +393,12 @@
       fileList: fileStagingTable.getData(),
       token: oauthToken
     };
+    for (var x = 0; x < fileData["fileList"].length; x++) {
+      var sel = document.getElementById(
+        `wpCategories${fileData["fileList"][x]["id"]}`
+      );
+      fileData["fileList"][x]["categories"] = sel.value;
+    }    
 
     function getCookie(name) {
       var cookieValue = null;

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -81,7 +81,7 @@ class FileUploadViewSet(views.APIView):
                 download_status, done = downloader.next_chunk()
 
             uploaded, image_info = wiki_uploader.upload_file(
-                file_name=file["name"], file_stream=fh, description=file["description"]
+                file_name=file["name"], file_stream=fh, description=file["description"], categories=file["categories"]
             )
             if uploaded:
                 uploaded_results.append(image_info)

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -23,7 +23,7 @@ class WikiUploader(object):
             access_secret=access_secret,
         )
 
-    def upload_file(self, file_name, file_stream, description=""):
+    def upload_file(self, file_name, file_stream, description="", categories=""):
         if not description:
             description = file_name
 
@@ -32,7 +32,7 @@ class WikiUploader(object):
             filename=file_name,
             description=description,
             ignore=True,
-            comment="Uploaded with Google drive to commons.",
+            comment=get_initial_page_text(categories, description),
         )
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
@@ -43,3 +43,9 @@ class WikiUploader(object):
             return False, {}
         else:
             return True, upload_result["imageinfo"]
+
+        
+
+def get_initial_page_text(categories="", summary=""):
+
+    return "== Summary ==\n{0}\n== Categories ==\n{{{{{1}}}}} ".format(summary, categories)


### PR DESCRIPTION
Users can select the category to which the image belongs to from a given list of categories in the drop down before they upload the image to Wikimedia commons as shown below. 
![image](https://user-images.githubusercontent.com/46782283/77004142-9e42d100-6984-11ea-82fb-48c94c93cc44.png)
