### PR TITLE
After login, Displaying folders and images for user to select

### DIFF
--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -272,7 +272,7 @@
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
       var view = new google.picker.DocsView().setIncludeFolders(true);
-      view.setMimeTypes("");
+      view.setMimeTypes("image/jpeg,image/jpg,image/gif,image/png,image/bmp");
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -273,6 +273,7 @@
     if (pickerApiLoaded && oauthToken) {
       var view = new google.picker.DocsView().setIncludeFolders(true);
       view.setMimeTypes("image/jpeg,image/jpg,image/gif,image/png,image/bmp");
+      view.setParent('root');
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -271,8 +271,8 @@
   // Create and render a Picker object for searching images.
   function createPicker() {
     if (pickerApiLoaded && oauthToken) {
-      var view = new google.picker.View(google.picker.ViewId.DOCS);
-      view.setMimeTypes("image/png,image/jpeg,image/jpg");
+      var view = new google.picker.DocsView().setIncludeFolders(true);
+      view.setMimeTypes("");
       var picker = new google.picker.PickerBuilder()
         .enableFeature(google.picker.Feature.NAV_HIDDEN)
         .enableFeature(google.picker.Feature.MULTISELECT_ENABLED)


### PR DESCRIPTION
In the tool, after selecting the "choose photos from google drive" button, images are displayed in a random order and this pull request fixes this issue. Folders are first displayed after selecting "choose photos from google drive" button as shown below.

![image](https://user-images.githubusercontent.com/46782283/77802037-0f2e6b00-70a0-11ea-93c7-81320df58133.png)

Then we can navigate through folders and view files and sub folders as shown below

![image](https://user-images.githubusercontent.com/46782283/77802098-2cfbd000-70a0-11ea-8d24-cf7a93f2bfdd.png)

To view only images after navigating to a folder, select file type as images from advanced search options as shown below

![image](https://user-images.githubusercontent.com/46782283/77802133-3dac4600-70a0-11ea-8759-6876aeb32872.png)

![image](https://user-images.githubusercontent.com/46782283/77802143-456bea80-70a0-11ea-871c-9386c5fbce92.png)

Then select the images to upload to Wikimedia commons. We can select multiple images randomly by selecting the images while pressing the CTRL button as shown below. This Fixes tonythomas01/gdrive-to-commons-repo#34

![image](https://user-images.githubusercontent.com/46782283/77802158-4d2b8f00-70a0-11ea-824f-9b4dd4c45f60.png)

After this we can upload the images to Wikimedia commons.

Fixes tonythomas01/gdrive-to-commons-repo#33

