### PR TITLE
Add Date Created metadata field for each file

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -18,3 +18,6 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+**Phabricator link**
+Create a task under project https://phabricator.wikimedia.org/tag/google-drive-to-commons/ and link it here ?

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, fields
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
+    datecreated = serializers.DateField(format='', input_formats='')
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers, fields
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
-    datecreated = serializers.DateField(format='', input_formats='')
+    datecreated = serializers.DateField(initial=datetime.date.today, format='', input_formats='')
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,1 +1,6 @@
-<input type="date" name="DateCreated" id="datecreated" onchange="TDate()" required />
+<div class="form-group row">
+	<label for="DateCreated" class="col-2 col-form-label"></label>
+	<div class="col-10">
+		<input class="form-control" type="date" name="DateCreated" id="DateCreated" onchange="TDate()" required />
+	</div>	
+</div>	

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,0 +1,1 @@
+<input type="date" name="DateCreated" id="datecreated" onchange="TDate()" required />

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -241,6 +241,16 @@
   var oauthToken;
   var fileStagingTable;
 
+function TDate() {
+var UserDate = document.getElementById("datecreated").value;
+var ToDate = new Date();
+
+if (new Date(UserDate).getTime() > ToDate.getTime()) {
+    alert("The Date created must be Less than or Equal to today's date");
+    return document.getElementById("datecreated").value = null;
+}
+return true;}  
+  
   // Use the Google API Loader script to load the google.picker script.
   function onGoogleUploadButtonClick() {
     gapi.load("auth", { callback: onAuthApiLoad });
@@ -325,6 +335,13 @@
             validator: "unique"
           },
           {
+            title: "DateCreated",
+            field: "datecreated",
+            formatter: function(cell, formatterParams, onRendered) {
+              return `{% include 'datepicker.html' %}`;
+            }
+          },           
+          {
             title: "Description",
             field: "description",
             editor: "textarea",
@@ -353,6 +370,13 @@
       token: oauthToken
     };
 
+    for (var x = 0; x < fileData["fileList"].length; x++) {
+      var sel = document.getElementById(
+        `DateCreated${fileData["fileList"][x]["id"]}`
+      );
+      fileData["fileList"][x]["datecreated"] = sel.value;
+    }     
+    
     function getCookie(name) {
       var cookieValue = null;
       if (document.cookie && document.cookie !== "") {

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -245,11 +245,27 @@ function TDate() {
 var UserDate = document.getElementById("datecreated").value;
 var ToDate = new Date();
 
-if (new Date(UserDate).getTime() > ToDate.getTime()) {
-    alert("The Date created must be Less than or Equal to today's date");
-    return document.getElementById("datecreated").value = null;
-}
-return true;}  
+  function TDate() 
+  {
+    var dc = document.getElementById("DateCreated").value;
+    var Today = new Date();
+    var dd = Today.getDate(); 
+    var mm = Today.getMonth() + 1; //January is 0! 
+    var yyyy = Today.getFullYear(); 
+    if (dd < 10) 
+      { dd = '0' + dd; } 
+    if (mm < 10) 
+      { mm = '0' + mm; }
+    var dmy = yyyy+'-'+mm+'-'+dd;
+    if (new Date(dc).getTime() > Today.getTime()) 
+    {
+
+      alert("The Date created must be Less than or Equal to today's date");
+      //return document.getElementById("datecreated").value = null;
+      return DateCreated.value = dmy;
+    }
+    return true
+  }
   
   // Use the Google API Loader script to load the google.picker script.
   function onGoogleUploadButtonClick() {
@@ -335,12 +351,13 @@ return true;}
             validator: "unique"
           },
           {
-            title: "DateCreated",
+            title: "Date work was created or first published",
             field: "datecreated",
+            width: 350,
             formatter: function(cell, formatterParams, onRendered) {
               return `{% include 'datepicker.html' %}`;
-            }
-          },           
+            } 
+          },  
           {
             title: "Description",
             field: "description",
@@ -371,11 +388,9 @@ return true;}
     };
 
     for (var x = 0; x < fileData["fileList"].length; x++) {
-      var sel = document.getElementById(
-        `DateCreated${fileData["fileList"][x]["id"]}`
-      );
-      fileData["fileList"][x]["datecreated"] = sel.value;
-    }     
+      var sel = document.getElementById(`DateCreated`);
+      fileData["fileList"][x]["DateCreated"] = sel.value;
+    }   
     
     function getCookie(name) {
       var cookieValue = null;

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -81,7 +81,7 @@ class FileUploadViewSet(views.APIView):
                 download_status, done = downloader.next_chunk()
 
             uploaded, image_info = wiki_uploader.upload_file(
-                file_name=file["name"], file_stream=fh, description=file["description"]
+                file_name=file["name"], file_stream=fh, datecreated=file["datecreated"], description=file["description"]
             )
             if uploaded:
                 uploaded_results.append(image_info)

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -30,10 +30,9 @@ class WikiUploader(object):
         upload_result = self.mw_client.upload(
             file=file_stream,
             filename=file_name,
-            datecreated=datecreated,
             description=description,
             ignore=True,
-            comment="Uploaded with Google drive to commons.",
+            comment=get_initial_page_text(datecreated, description),
         )
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
@@ -44,3 +43,17 @@ class WikiUploader(object):
             return False, {}
         else:
             return True, upload_result["imageinfo"]
+        
+def get_initial_page_text(datecreated="", summary=""):
+
+    return """=={{{{int:filedesc}}}}==
+{{{{Information|
+{{{{en|{0}}}}}
+}}}}
+=={{{{int:license-header}}}}==
+{{{{{1}}}}}
+[[Category:{2}]] 
+""".format(
+        summary, datecreated
+    )        
+        

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -23,13 +23,14 @@ class WikiUploader(object):
             access_secret=access_secret,
         )
 
-    def upload_file(self, file_name, file_stream, description=""):
+    def upload_file(self, file_name, file_stream, datecreated="", description=""):
         if not description:
             description = file_name
 
         upload_result = self.mw_client.upload(
             file=file_stream,
             filename=file_name,
+            datecreated=datecreated,
             description=description,
             ignore=True,
             comment="Uploaded with Google drive to commons.",


### PR DESCRIPTION
Users can select the date the image has been created by selecting a date from the datepicker developed.

After the user selects the photo and proceeds to the "Upload to Wikimedia commons" button page, The user can select a date on which the image has been created using the datepicker as shown below.

![Screenshot from 2020-03-31 08-01-16](https://user-images.githubusercontent.com/46782283/77981036-7c533200-7326-11ea-9cc7-af9f47777180.png)

If the user selects a date greater than the today's date, then a alert message appears on the top of the screen saying that "The Date created must be Less than or Equal to today's date" as shown below.

![image](https://user-images.githubusercontent.com/46782283/77980855-11096000-7326-11ea-9d85-ecd37add0dab.png)

And then the value of the datepicker is again set back to null. 
After the user selects a suitable date, the datepicker displays the selected date as shown below. 

![image](https://user-images.githubusercontent.com/46782283/77980930-3e560e00-7326-11ea-8e01-c541f0b109a6.png)
