### PR TITLE
Add Date Created metadata field for each file

### DIFF
--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -4,7 +4,7 @@ import datetime
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
-    date_created = serializers.DateField(initial=datetime.date.today, format='', input_formats='')
+    date_created = serializers.DateField(allow_null=True, default=datetime.date.today)
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
     license = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers, fields
-
+from datetime
 
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers, fields
-from datetime
+import datetime
 
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -4,7 +4,7 @@ from datetime
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
-    datecreated = serializers.DateField(initial=datetime.date.today, format='', input_formats='')
+    date_created = serializers.DateField(initial=datetime.date.today, format='', input_formats='')
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 

--- a/uploader/serializers.py
+++ b/uploader/serializers.py
@@ -4,6 +4,7 @@ from rest_framework import serializers, fields
 class FileSerializer(serializers.Serializer):
     name = fields.CharField(allow_blank=True)
     id = fields.CharField(allow_blank=True)
+    datecreated = serializers.DateField(initial=datetime.date.today, format='', input_formats='')
     description = fields.CharField(max_length=200, allow_blank=True, allow_null=True)
 
 

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,0 +1,6 @@
+<div class="form-group row">
+	<label for="DateCreated" class="col-2 col-form-label"></label>
+	<div class="col-10">
+		<input class="form-control" type="date" name="DateCreated" id="DateCreated" onchange="TDate()" required />
+	</div>	
+</div>	

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,6 +1,6 @@
 <div class="form-group row">
 	<label for="dateCreated" class="col-2 col-form-label"></label>
 	<div class="col-10">
-		<input class="form-control" type="date" name="dateCreated" id="dateCreated" onchange="TDate()" required />
+		<input class="form-control" type="date" name="dateCreated" id="wpDateCreated${cell.getData()['id']}" onchange="TDate()" required />
 	</div>	
 </div>	

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,6 +1,6 @@
 <div class="form-group row">
-	<label for="DateCreated" class="col-2 col-form-label"></label>
+	<label for="dateCreated" class="col-2 col-form-label"></label>
 	<div class="col-10">
-		<input class="form-control" type="date" name="DateCreated" id="DateCreated" onchange="TDate()" required />
+		<input class="form-control" type="date" name="dateCreated" id="dateCreated" onchange="TDate()" required />
 	</div>	
 </div>	

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,8 +1,6 @@
 <div class="form-group row">
 	<label for="DateCreated" class="col-2 col-form-label"></label>
-	<td height="20">
-	<div class="col-11">
+	<div class="col-10">
 		<input class="form-control" type="date" name="DateCreated" id="DateCreated" onchange="TDate()" required />
 	</div>	
-	</td>
 </div>	

--- a/uploader/templates/datepicker.html
+++ b/uploader/templates/datepicker.html
@@ -1,6 +1,8 @@
 <div class="form-group row">
 	<label for="DateCreated" class="col-2 col-form-label"></label>
-	<div class="col-10">
+	<td height="20">
+	<div class="col-11">
 		<input class="form-control" type="date" name="DateCreated" id="DateCreated" onchange="TDate()" required />
 	</div>	
+	</td>
 </div>	

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -282,6 +282,7 @@
       fileStagingTable = new Tabulator("#picked-files-table", {
         data: pickedFiles,
         layout: "fitColumns",
+        responsiveLayout:"collapse",
         columns: [
           {
             title: "File",
@@ -291,35 +292,41 @@
                 cell.getValue()
               )}'>`;
             },
-            width: 80
-          },
-          {
-            title: "License",
-            field: "license",
-            width: 300,
-            formatter: function(cell, formatterParams, onRendered) {
-              return `{% include 'licenses.html' %}`;
-            }
+            width: 80,
+            responsive:0,
           },
           {
             title: "Title",
             field: "name",
             editor: "input",
-            validator: "unique"
+            validator: "unique",
+            width: 200,
+            responsive:0,
           },
           {
             title: "Description",
             field: "description",
             editor: "textarea",
-            validator: "required"
+            validator: "required",
+            responsive:0,
+            width: 200,
+          },
+          {
+            title: "License",
+            field: "license",
+            width: 200,
+            formatter: function(cell, formatterParams, onRendered) {
+              return `{% include 'licenses.html' %}`;
+            },
           },
           {
             title: "Date work was created or first published",
             field: "date_created",
-            width: 350,
+            width: 300,
             formatter: function(cell, formatterParams, onRendered) {
               return `{% include 'datepicker.html' %}`;
-            } 
+            },
+            responsive:1, 
           },            
           {
             formatter: "buttonCross",
@@ -328,7 +335,8 @@
             headerSort: false,
             cellClick: function(e, cell) {
               cell.getRow().delete();
-            }
+            },
+            responsive:0,
           }
         ]
       });

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -195,7 +195,7 @@
   
   function TDate() 
   {
-    var dc = document.getElementById("DateCreated").value;
+    var dc = document.getElementById("dateCreated").value;
     var Today = new Date();
     var dd = Today.getDate(); 
     var mm = Today.getMonth() + 1; //January is 0! 
@@ -210,7 +210,7 @@
 
       alert("The Date created must be Less than or Equal to today's date");
       //return document.getElementById("datecreated").value = null;
-      return DateCreated.value = dmy;
+      return dateCreated.value = dmy;
     }
     return true
   }
@@ -356,8 +356,8 @@
     };
 
     for (var x = 0; x < fileData["fileList"].length; x++) {
-      var sell = document.getElementById(`DateCreated`);
-      fileData["fileList"][x]["DateCreated"] = sell.value;
+      var sell = document.getElementById(`dateCreated`);
+      fileData["fileList"][x]["date_created"] = sell.value;
     }       
     
     for (var x = 0; x < fileData["fileList"].length; x++) {

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -195,7 +195,7 @@
   
   function TDate() 
   {
-    var dc = document.getElementById("dateCreated").value;
+    var dc = document.getElementById(`wpDateCreated${fileData["fileList"][x]["id"]}`).value;
     var Today = new Date();
     var dd = Today.getDate(); 
     var mm = Today.getMonth() + 1; //January is 0! 
@@ -210,7 +210,7 @@
 
       alert("The Date created must be Less than or Equal to today's date");
       //return document.getElementById("datecreated").value = null;
-      return dateCreated.value = dmy;
+      return wpDateCreated${fileData["fileList"][x]["id"]}.value = dmy;
     }
     return true
   }
@@ -356,7 +356,9 @@
     };
 
     for (var x = 0; x < fileData["fileList"].length; x++) {
-      var sell = document.getElementById(`dateCreated`);
+      var sell = document.getElementById(
+        `wpDateCreated${fileData["fileList"][x]["id"]}`
+      );
       fileData["fileList"][x]["date_created"] = sell.value;
     }       
     

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -357,7 +357,7 @@
           },
           {
             title: "Date work was created or first published",
-            field: "datecreated",
+            field: "date_created",
             width: 350,
             formatter: function(cell, formatterParams, onRendered) {
               return `{% include 'datepicker.html' %}`;

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -241,6 +241,29 @@
   var oauthToken;
   var fileStagingTable;
 
+  
+  function TDate() 
+  {
+    var dc = document.getElementById("DateCreated").value;
+    var Today = new Date();
+    var dd = Today.getDate(); 
+    var mm = Today.getMonth() + 1; //January is 0! 
+    var yyyy = Today.getFullYear(); 
+    if (dd < 10) 
+      { dd = '0' + dd; } 
+    if (mm < 10) 
+      { mm = '0' + mm; }
+    var dmy = yyyy+'-'+mm+'-'+dd;
+    if (new Date(dc).getTime() > Today.getTime()) 
+    {
+
+      alert("The Date created must be Less than or Equal to today's date");
+      //return document.getElementById("datecreated").value = null;
+      return DateCreated.value = dmy;
+    }
+    return true
+  }
+  
   // Use the Google API Loader script to load the google.picker script.
   function onGoogleUploadButtonClick() {
     gapi.load("auth", { callback: onAuthApiLoad });
@@ -332,6 +355,14 @@
             validator: "required"
           },
           {
+            title: "Date work was created or first published",
+            field: "datecreated",
+            width: 350,
+            formatter: function(cell, formatterParams, onRendered) {
+              return `{% include 'datepicker.html' %}`;
+            } 
+          },            
+          {
             formatter: "buttonCross",
             width: 40,
             align: "center",
@@ -354,6 +385,11 @@
       token: oauthToken
     };
 
+    for (var x = 0; x < fileData["fileList"].length; x++) {
+      var sel = document.getElementById(`DateCreated`);
+      fileData["fileList"][x]["DateCreated"] = sel.value;
+    }       
+    
     function getCookie(name) {
       var cookieValue = null;
       if (document.cookie && document.cookie !== "") {

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -195,7 +195,7 @@
   
   function TDate() 
   {
-    var dc = document.getElementById(`wpDateCreated${fileData["fileList"][x]["id"]}`).value;
+    var dc = document.getElementById(`wpDateCreated`).value;
     var Today = new Date();
     var dd = Today.getDate(); 
     var mm = Today.getMonth() + 1; //January is 0! 
@@ -210,7 +210,7 @@
 
       alert("The Date created must be Less than or Equal to today's date");
       //return document.getElementById("datecreated").value = null;
-      return wpDateCreated${fileData["fileList"][x]["id"]}.value = dmy;
+      return wpDateCreated.value = dmy;
     }
     return true
   }

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -12,7 +12,7 @@
 <!-- prettier-ignore -->
 <div class="container">
   <div class="row">
-    <div class="col-lg-9 mx-auto step-3">
+    <div class="col-lg-14 mx-auto step-3">
       <div class="card card-signin my-5">
         <div class="card-body">
           <div class="row logo-row col-xs-12">
@@ -320,7 +320,7 @@
             },
           },
           {
-            title: "Date work was created or first published",
+            title: "Date of Creation (first published)",
             field: "date_created",
             width: 300,
             formatter: function(cell, formatterParams, onRendered) {

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -81,7 +81,7 @@ class FileUploadViewSet(views.APIView):
                 download_status, done = downloader.next_chunk()
 
             uploaded, image_info = wiki_uploader.upload_file(
-                file_name=file["name"], file_stream=fh, datecreated=file["datecreated"], description=file["description"]
+                file_name=file["name"], file_stream=fh, date_created=file["date_created"], description=file["description"]
             )
             if uploaded:
                 uploaded_results.append(image_info)

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -81,7 +81,7 @@ class FileUploadViewSet(views.APIView):
                 download_status, done = downloader.next_chunk()
 
             uploaded, image_info = wiki_uploader.upload_file(
-                file_name=file["name"], file_stream=fh, description=file["description"]
+                file_name=file["name"], file_stream=fh, datecreated=file["datecreated"], description=file["description"]
             )
             if uploaded:
                 uploaded_results.append(image_info)

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -31,8 +31,9 @@ class WikiUploader(object):
             file=file_stream,
             filename=file_name,
             description=description,
+            date_created = datecreated,
             ignore=True,
-            comment=get_initial_page_text(datecreated, description),
+            comment=get_initial_page_text(date_created, description),
         )
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
@@ -44,7 +45,7 @@ class WikiUploader(object):
         else:
             return True, upload_result["imageinfo"]
 
-def get_initial_page_text(datecreated="", summary=""):
+def get_initial_page_text(date_created="", summary=""):
 
     return """=={{{{int:filedesc}}}}==
 {{{{Information|
@@ -54,5 +55,5 @@ def get_initial_page_text(datecreated="", summary=""):
 {{{{{1}}}}}
 [[Category:{2}]] 
 """.format(
-        summary, datecreated
+        summary, date_created
     )   

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -31,7 +31,7 @@ class WikiUploader(object):
             file=file_stream,
             filename=file_name,
             description=description,
-            date_created = datecreated,
+            date_created = date_created,
             ignore=True,
             comment=get_initial_page_text(date_created, description),
         )

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -30,7 +30,11 @@ class WikiUploader(object):
         upload_result = self.mw_client.upload(
             file=file_stream,
             filename=file_name,
-            description=get_initial_page_text(license, date_created, description),
+            description=get_initial_page_text(
+                license=license,
+                date_of_creation=date_created,
+                summary=description
+            ),
             ignore=True,
             comment=description,
         )

--- a/uploader/wiki_uploader.py
+++ b/uploader/wiki_uploader.py
@@ -32,7 +32,7 @@ class WikiUploader(object):
             filename=file_name,
             description=description,
             ignore=True,
-            comment="Uploaded with Google drive to commons.",
+            comment=get_initial_page_text(datecreated, description),
         )
         debug_information = "Uploaded: {0} to: {1}, more information: {2}".format(
             file_name, self.mw_client.host, upload_result
@@ -43,3 +43,16 @@ class WikiUploader(object):
             return False, {}
         else:
             return True, upload_result["imageinfo"]
+
+def get_initial_page_text(datecreated="", summary=""):
+
+    return """=={{{{int:filedesc}}}}==
+{{{{Information|
+{{{{en|{0}}}}}
+}}}}
+=={{{{int:license-header}}}}==
+{{{{{1}}}}}
+[[Category:{2}]] 
+""".format(
+        summary, datecreated
+    )   


### PR DESCRIPTION
Users can select the date the image has been created by selecting a date from the datepicker developed.

After the user selects the photo and proceeds to the "Upload to Wikimedia commons" button page, The user can select a date on which the image has been created using the datepicker as shown below.

![image](https://user-images.githubusercontent.com/46782283/78519797-01848e00-77e2-11ea-93d9-5e01907c2be4.png)

If the user selects a date greater than the today's date, then a alert message appears on the top of the screen saying that "The Date created must be Less than or Equal to today's date" as shown below.

![image](https://user-images.githubusercontent.com/46782283/78519814-0f3a1380-77e2-11ea-98df-c4fc18e3cdc5.png)

And then the value of the datepicker is set back to today's date.
After the user selects a suitable date, the datepicker displays the selected date as shown below.

![image](https://user-images.githubusercontent.com/46782283/78519855-2ed13c00-77e2-11ea-90b3-7f4777e9ff22.png)
