### PR TITLE
Add: note for user displaying "metadata fields are editable"

### DIFF
--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -31,6 +31,7 @@
                         </div>
 
                         <h5 class="app-desc text-center">Your selected file(s):</h5>
+                        <h5 class="app-desc text-left" style="font-size:12px;">*Metadata fields are editable</h5>
                         <div class="table-responsive">
                             <table class="table files-table"
                                    id="picked-files-table">


### PR DESCRIPTION
If we observe the user interface of the upload to Wikimedia commons page, it is not clear that the metadata fields can be edited.
Hence a change in the html code of the upload to Wikimedia commons page is proposed to inform the user that they can edit the metadata fields. A text note saying "metadata fields are editable" is displayed in the left side just below the line "your selected file(s)" as shown below.

![image](https://user-images.githubusercontent.com/46782283/78585752-03893400-7858-11ea-8e80-af717d46e41a.png)
