### PR TITLE
Add: used django-csp to handle content security policies

### DIFF
--- a/gdrive_to_commons/settings.py
+++ b/gdrive_to_commons/settings.py
@@ -41,6 +41,7 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
+    "csp.middleware.CSPMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
@@ -115,5 +116,21 @@ LOGIN_URL = "login"
 LOGIN_REDIRECT_URL = "upload_page"
 LOGOUT_REDIRECT_URL = "home_page"
 SOCIAL_AUTH_URL_NAMESPACE = "social"
+
+CSP_DEFAULT_SRC = ("'self'", "*.google.com   ")
+CSP_STYLE_SRC = ("'self'", "'unsafe-inline'")
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-inline'", "*.google.com")
+CSP_IMG_SRC = (
+    "'self'",
+    "www.w3.org",
+    "data:",
+    "*.google.com",
+    "*.googleusercontent.com",
+)
+CSP_FRAME_SRC = ("'self'", "'unsafe-inline'", "*.google.com")
+CSP_FONT_SRC = (
+    "'self'",
+    "'unsafe-inline'",
+)
 
 from gdrive_to_commons.local_settings import *

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ chardet==3.0.4
 Click==7.0
 defusedxml==0.6.0
 Django==2.2.1
+django-csp==3.6
 djangorestframework==3.9.4
 Flask==1.0.3
 google==2.0.2
@@ -26,6 +27,7 @@ mwauth==0.4.27
 mwclient==0.9.3
 nodeenv==1.3.3
 oauthlib==3.0.1
+p==0.0.0
 pre-commit==1.16.1
 pyasn1==0.4.5
 pyasn1-modules==0.2.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ mwauth==0.4.27
 mwclient==0.9.3
 nodeenv==1.3.3
 oauthlib==3.0.1
-p==0.0.0
 pre-commit==1.16.1
 pyasn1==0.4.5
 pyasn1-modules==0.2.5

--- a/uploader/templates/base/base.html
+++ b/uploader/templates/base/base.html
@@ -3,16 +3,6 @@
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-
-    <meta
-      http-equiv="Content-Security-Policy"
-      content="default-src 'self' https://* http://*;
-          img-src 'self' https://*;
-          style-src 'self' 'unsafe-inline';
-          script-src 'self' 'unsafe-inline' https://* http://*;
-          script-src-elem 'self' https://* http://* 'unsafe-inline';"
-    />
-
     {% block meta %} {% endblock %}
     <link
       rel="stylesheet"


### PR DESCRIPTION
As per the discussions in #45 and `T248251` , the problem was CSP instead of CORS. Since we are using django-html only, CORS isn't a problem, but third-party scripts were causing the problems. 

I have removed the `<meta>`  tag hard coded into `base.html` and I have added the configurations in the `settings.py` file.

![image](https://user-images.githubusercontent.com/36009198/78636756-8fd24000-78c6-11ea-834b-fd181e08f3d1.png)

