### PR TITLE
Adding feedback option to the tool

### DIFF
--- a/gdrive_to_commons/settings.py
+++ b/gdrive_to_commons/settings.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "uploader",
     "rest_framework",
     "social_django",
+    "tellme",
 ]
 
 MIDDLEWARE = [

--- a/gdrive_to_commons/urls.py
+++ b/gdrive_to_commons/urls.py
@@ -32,5 +32,6 @@ urlpatterns = [
     path(r"admin/", admin.site.urls),
     url(r"^api-auth/", include("rest_framework.urls")),
     url(r"^oauth/", include("social_django.urls", namespace="social")),
+    url(r'^tellme/', include("tellme.urls")),
     path("", HomePageView.as_view(), name="home_page"),
 ] + static(settings.STATIC_URL_DEPLOYMENT, document_root=settings.STATIC_ROOT)

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -214,6 +214,7 @@
             </div>
         </div>
     </div>
+{%  include 'tellme/js_inc.html' %}  
 <!-- prettier-ignore -->
 {% endblock body %}
 <!-- prettier-ignore -->

--- a/uploader/templates/upload.html
+++ b/uploader/templates/upload.html
@@ -8,8 +8,12 @@
   rel="stylesheet"
   crossorigin="anonymous"
 />
+<link href="{% static 'tellme/feedback.min.css' %}" rel="stylesheet">
 {% endblock %} {% block body %}
 <!-- prettier-ignore -->
+<button type="button" id="feedback-btn" class="btn btn-info vertical-right-aligned">
+    Feedback <span class="glyphicon glyphicon-bullhorn" aria-hidden="true"></span>
+</button>
 <div class="container">
         <div class="row">
             <div class="col-lg-8 mx-auto step-3">


### PR DESCRIPTION
The user might face problem while operating the tool or the user might want to notify us by sending suggestions, errors, corrections or updates to us that they want about this tool. 
Therefore, a feedback button is added to the app such that the button is visible on every page of the app (since we don't know when the user faces a problem. If he faces a problem in between he can immediately click on feedback button and send notify us with the feedback) 
The button is visible on every page of the tool as shown below
![image](https://user-images.githubusercontent.com/46782283/78675426-adbd9600-7902-11ea-9cf2-fb7693bf10a5.png)
After we click on the feedback button a pop-up appears as shown below
![image](https://user-images.githubusercontent.com/46782283/78675518-cf1e8200-7902-11ea-8a26-c7883fbcfffe.png)
In this pop up there are two fields, one is email field and other is feedback field. In email field user can enter their email id to get response from admin or they can even leave it blank.
In the feedback field the user can give feedback about the tool.
After filling both the fields or only the feedback field the user should click on submit button as shown below.
![image](https://user-images.githubusercontent.com/46782283/78675872-4bb16080-7903-11ea-98c1-5c2171a087c4.png)
After clicking on the submit button, a popup message appears saying "Thank you for your feedback We value every piece of feedback we receive." as shiown below
![image](https://user-images.githubusercontent.com/46782283/78676097-9e8b1800-7903-11ea-9f5a-abde88d5b178.png)
After clicking on OK button, the user can continue using the tool normally.

PREREQUISITE: before making the change a package has to be downloaded by pasting the following command in terminal: pip install django-tellme